### PR TITLE
remove `x-ua-compatible` meta tag from template

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,8 +8,6 @@
 
     <title>{% block title %}{{ 'page.default_title'|trans({}, 'w3c_website_templates_bundle') }}{% endblock %}</title>
 
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-
     <meta property="og:description" name="description"
           content="{% block description %}{{ 'page.default_description'|trans({}, 'w3c_website_templates_bundle') }}{% endblock %}"/>
     


### PR DESCRIPTION
modern browsers and IE11 don't need it.

fixes #13 