### PR TITLE
Base template refactoring

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -59,7 +59,7 @@
     {% endblock javascripts %}
 </head>
 
-<body class="default">
+<body class="{{ body_classes|default('default') }}">
 <a class="skip-link" href="#main">{{ 'page.skip_to_content'|trans({}, 'w3c_website_templates_bundle') }}</a>
 <div class="grid-wrap">
     <div class="wrap">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -83,23 +83,7 @@
             {% endif %}
         {% endblock breadcrumbs %}
         <main id="main">
-            <div class="content">
-                <article>
-                    <h1>{{ block('title') }}</h1>
-                    {% if page_translations is defined and page_translations|length > 0 %}
-                        {{ include('@W3CWebsiteTemplates/components/styles/page_translations.html.twig') }}
-                    {% endif %}
-                    {% if toc is defined %}
-                        {{ include('@W3CWebsiteTemplates/components/styles/toc.html.twig') }}
-                    {% endif %}
-                    {% block body %}{% endblock body %}
-                </article>
-                {% block related %}
-                    {% if related_links is defined %}
-                        {{ include('@W3CWebsiteTemplates/components/styles/related.html.twig') }}
-                    {% endif %}
-                {% endblock %}
-            </div>
+            {% block main %}{% endblock %}
         </main>
         {% block crosslinks %}
             {% if crosslinks is defined and crosslinks|length > 0 %}
@@ -108,36 +92,7 @@
         {% endblock crosslinks %}
     </div>
     {% block footer %}
-        <footer class="global-footer">
-            <div class="l-center">
-                <div class="global-footer__links">
-                    <div class="l-cluster">
-                        <ul class="clean-list" role="list">
-                            <li><a href="../page.html">{{ 'footer.links.home'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.contact'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.help'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.sponsor_donate'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.privacy_policy'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.legal'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                            <li><a href="../page.html">{{ 'footer.links.system_status'|trans({}, 'w3c_website_templates_bundle') }}</a></li>
-                        </ul>
-                    </div>
-                    <ul class="clean-list" role="list">
-                        <li><a class="with-icon--larger" href="https://twitter.com/W3C">
-                                <img class="icon icon--larger" src="{{ asset('svg/twitter.svg', 'main') }}" width="20" height="20" alt
-                                     aria-hidden="true"/>
-                                <span class="visuallyhidden">{{ 'footer.links.twitter'|trans({}, 'w3c_website_templates_bundle') }}</span></a>
-                        </li>
-                        <li><a class="with-icon--larger" href="https://github.com/w3c/">
-                                <img class="icon icon--larger" src="{{ asset('svg/github.svg', 'main') }}" width="20" height="20" alt
-                                     aria-hidden="true"/>
-                                <span class="visuallyhidden">{{ 'footer.links.github'|trans({}, 'w3c_website_templates_bundle') }}</span></a>
-                        </li>
-                    </ul>
-                </div>
-                <p class="copyright">{{ 'footer.copyright'|trans({'date': date('now')}, 'w3c_website_templates_bundle')|raw }}</p>
-            </div>
-        </footer>
+        {{ include('@W3CWebsiteTemplates/components/styles/footer.html.twig') }}
     {% endblock %}
 </div>
 

--- a/templates/base_page.html.twig
+++ b/templates/base_page.html.twig
@@ -1,0 +1,21 @@
+{% extends '@W3CWebsiteTemplates/base.html.twig' %}
+
+{% block main %}
+    <div class="content">
+        <article>
+            <h1>{{ block('title') }}</h1>
+            {% if page_translations is defined and page_translations|length > 0 %}
+                {{ include('@W3CWebsiteTemplates/components/styles/page_translations.html.twig') }}
+            {% endif %}
+            {% if toc is defined %}
+                {{ include('@W3CWebsiteTemplates/components/styles/toc.html.twig') }}
+            {% endif %}
+            {% block body %}{% endblock body %}
+        </article>
+        {% block related %}
+            {% if related_links is defined %}
+                {{ include('@W3CWebsiteTemplates/components/styles/related.html.twig') }}
+            {% endif %}
+        {% endblock %}
+    </div>
+{% endblock %}

--- a/templates/components/styles/footer.html.twig
+++ b/templates/components/styles/footer.html.twig
@@ -1,0 +1,43 @@
+<footer class="global-footer">
+    <div class="l-center">
+        <div class="global-footer__links">
+            <div class="l-cluster">
+                <ul class="clean-list" role="list">
+                    <li><a href="../page.html">{{ 'footer.links.home'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li>
+                        <a href="../page.html">{{ 'footer.links.contact'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li><a href="../page.html">{{ 'footer.links.help'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li>
+                        <a href="../page.html">{{ 'footer.links.sponsor_donate'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li>
+                        <a href="../page.html">{{ 'footer.links.privacy_policy'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li><a href="../page.html">{{ 'footer.links.legal'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                    <li>
+                        <a href="../page.html">{{ 'footer.links.system_status'|trans({}, 'w3c_website_templates_bundle') }}</a>
+                    </li>
+                </ul>
+            </div>
+            <ul class="clean-list" role="list">
+                <li><a class="with-icon--larger" href="https://twitter.com/W3C">
+                        <img class="icon icon--larger" src="{{ asset('svg/twitter.svg', 'main') }}" width="20"
+                             height="20" alt
+                             aria-hidden="true"/>
+                        <span class="visuallyhidden">{{ 'footer.links.twitter'|trans({}, 'w3c_website_templates_bundle') }}</span></a>
+                </li>
+                <li><a class="with-icon--larger" href="https://github.com/w3c/">
+                        <img class="icon icon--larger" src="{{ asset('svg/github.svg', 'main') }}" width="20"
+                             height="20" alt
+                             aria-hidden="true"/>
+                        <span class="visuallyhidden">{{ 'footer.links.github'|trans({}, 'w3c_website_templates_bundle') }}</span></a>
+                </li>
+            </ul>
+        </div>
+        <p class="copyright">{{ 'footer.copyright'|trans({'date': date('now')}, 'w3c_website_templates_bundle')|raw }}</p>
+    </div>
+</footer>


### PR DESCRIPTION
Footer has been extracted to its own template.
A new base template for landing pages is required as some of the markup should not be shared with other page types