### PR TITLE
provide ability to add new body classes when extending a template

### DIFF
--- a/templates/pages/ecosystem.html.twig
+++ b/templates/pages/ecosystem.html.twig
@@ -9,7 +9,7 @@
     {% endif %}
 {% endblock %}
 
-{% set body_classes = 'ecosystem' %}
+{% set body_classes = 'ecosystem' ~ body_classes|default('') %}
 
 {% block main %}
     {{ include('@W3CWebsiteTemplates/components/styles/hero.html.twig') }}

--- a/templates/pages/home.html.twig
+++ b/templates/pages/home.html.twig
@@ -1,6 +1,6 @@
 {% extends '@W3CWebsiteTemplates/base.html.twig' %}
 
-{% set body_classes = 'home' %}
+{% set body_classes = 'home' ~ body_classes|default('') %}
 
 {% block breadcrumbs %}{% endblock breadcrumbs %}
 

--- a/templates/pages/landing.html.twig
+++ b/templates/pages/landing.html.twig
@@ -1,6 +1,6 @@
 {% extends '@W3CWebsiteTemplates/base.html.twig' %}
 
-{% set body_classes = 'landing' %}
+{% set body_classes = 'landing' ~ body_classes|default('') %}
 
 {% block main %}
     {% block hero %}

--- a/templates/pages/listing.html.twig
+++ b/templates/pages/listing.html.twig
@@ -1,6 +1,6 @@
 {% extends '@W3CWebsiteTemplates/base.html.twig' %}
 
-{% set body_classes = 'listing' %}
+{% set body_classes = 'listing' ~ body_classes|default('') %}
 
 {% block main %}
     <div class="u-full-width hero hero--listing">


### PR DESCRIPTION
This provides the ability to pass new classes to the templates if necessary, e.g. `technical-reports` to the listing template (see [/TR page](https://design-system.w3.org/code/tr.html))