### PR TITLE
Removed the frame layout division in the image component.

### DIFF
--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -5,6 +5,7 @@
 ## Considerations
 
 Note the use of the [frame layout](../layouts/frame.md), to create the desired aspect ratio, and the `loading="lazy"` attribute on `<img>` for native lazy-loading.
+If you cannot anticipate the aspect ratio of images (e.g. if they are uploaded via a CMS without constraints on the image size), please omit the flame layout div.
 
 ### Alternative text
 

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -5,7 +5,7 @@
 ## Considerations
 
 Note the use of the [frame layout](../layouts/frame.md), to create the desired aspect ratio, and the `loading="lazy"` attribute on `<img>` for native lazy-loading.
-If you cannot anticipate the aspect ratio of images (e.g. if they are uploaded via a CMS without constraints on the image size), please omit the flame layout div.
+If you cannot anticipate the aspect ratio of images (e.g. if they are uploaded via a CMS without constraints on the image size), please omit the frame layout div.
 
 ### Alternative text
 

--- a/templates/components/image.html.twig
+++ b/templates/components/image.html.twig
@@ -1,5 +1,4 @@
 <figure class="component component--image">
-    <div class="l-frame l-frame--16-9">
         <img {% for key, value in attr %}{{ key }}="{{ value }}" {% endfor %}
             sizes="100vw"
             loading="lazy"
@@ -9,7 +8,6 @@
                 alt="{% if alt %}{{ alt }}{% endif %}"
             {% endif %}
            />
-    </div>
     {% if caption is defined and caption %}
         <figcaption>
             <p>{{ caption|raw }}</p>


### PR DESCRIPTION
I removed the frame layout division in the image component, which was forcing images to have a 16:9 aspect ratio. I don't think we want to impose an aspect ratio on generic content images, otherwise content authors have no way of uploading large portrait images or large images in any other aspect ratio.

I am working on ways to upload images via CKEditor as well. That would help with small images that might need to be floated on the left or right of the text content. Yet that caters for another use case (that of small images). I still think the image component shouldn't constrain an aspect ratio on larger images.

@simonrjones and @NicolaSaunders I'd like to make sure I've got your go ahead on that decision.

@NicolaSaunders Could you please also let me know whether I've missed out anything? Whether this could have an impact on other parts of the website/design system? Whether more CSS work is needed to make this work consistently with images of various aspect ratios?

Many thankts!