### PR TITLE
Fix expected type for flash messages

### DIFF
--- a/src/EventSubscriber/FlashMessageSubscriber.php
+++ b/src/EventSubscriber/FlashMessageSubscriber.php
@@ -53,7 +53,7 @@ class FlashMessageSubscriber implements EventSubscriberInterface
             'success' => 'successes',
             'warning' => 'warnings',
             'error'   => 'errors',
-            'notice'  => 'notices'
+            'info'    => 'info'
         ];
 
         $existingTitles = array_keys(


### PR DESCRIPTION
According to https://design-system.w3.org/components/notes.html, we should have 4 types of flash messages: `info`, `success`, `error` and `warning`