### PR TITLE
use raw filter on error message to allow markup

### DIFF
--- a/templates/form/theme.html.twig
+++ b/templates/form/theme.html.twig
@@ -89,7 +89,7 @@
     {%- if errors|length > 0 -%}
         <span class="field-error-msg" id="error-{{ form.vars.id }}">
             {%- for error in errors -%}
-                <span class="visuallyhidden">{{ 'Error'|trans({}, 'validators') }}</span> {{ error.message }}
+                <span class="visuallyhidden">{{ 'Error'|trans({}, 'validators') }}</span> {{ error.message|raw }}
             {%- endfor -%}
         </span>
     {%- endif -%}


### PR DESCRIPTION
That PR will allow the use of markup in error messages.
With this `raw` filter applied, we need to make sure the error message doesn't display a user's input.