### PR TITLE
Update links in footer

### DIFF
--- a/translations/w3c_website_templates_bundle+intl-icu.en.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.en.yaml
@@ -25,11 +25,11 @@ page:
 footer:
     copyright: >-
         Copyright &copy; {date, date, ::y} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
-          <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-          <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-          title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+        <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
+        <a href="https://www.w3.org/policies/#dislaimers">liability</a>,
+        <a href="https://www.w3.org/policies/#trademarks">trademark</a> and
+        <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software License">permissive license</a>
+        rules apply.
     links:
         hreflang: en
         home: Home

--- a/translations/w3c_website_templates_bundle+intl-icu.en.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.en.yaml
@@ -26,7 +26,7 @@ footer:
     copyright: >-
         Copyright &copy; {date, date, ::y} <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
         <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
-        <a href="https://www.w3.org/policies/#dislaimers">liability</a>,
+        <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
         <a href="https://www.w3.org/policies/#trademarks">trademark</a> and
         <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software License">permissive license</a>
         rules apply.

--- a/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
@@ -23,7 +23,10 @@ page:
 footer:
     copyright: >-
         版权所有 &copy; {date, date, ::y} <a href="https://www.w3.org/">万维网联盟</a>。<br>
-        遵循 <abbr title="万维网联盟">W3C</abbr><sup>&reg;</sup><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">责任声明</a>、<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">标志使用</a>以及<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C软件和文档声明和许可政策">文档许可政策</a>。
+        遵循 <abbr title="万维网联盟">W3C</abbr><sup>&reg;</sup>
+        <a href="https://www.w3.org/policies/#dislaimers">责任声明</a>、
+        <a href="https://www.w3.org/policies/#trademarks">标志使用</a>以及
+        <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C 软件许可">使用许可</a>。
     links:
         hreflang: zh-hans
         home: 主页

--- a/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
@@ -24,7 +24,7 @@ footer:
     copyright: >-
         版权所有 &copy; {date, date, ::y} <a href="https://www.w3.org/">万维网联盟</a>。<br>
         遵循 <abbr title="万维网联盟">W3C</abbr><sup>&reg;</sup>
-        <a href="https://www.w3.org/policies/#dislaimers">责任声明</a>、
+        <a href="https://www.w3.org/policies/#disclaimers">责任声明</a>、
         <a href="https://www.w3.org/policies/#trademarks">标志使用</a>以及
         <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C 软件许可">使用许可</a>。
     links:


### PR DESCRIPTION
Fix the Copyright footer links to use the new URIs.

Note that the Chinese version still points to the English pages as those have not yet been translated.