### PR TITLE
latest version URI for W3C Software and License

### DIFF
--- a/design-system-templates/components/footer.html.twig
+++ b/design-system-templates/components/footer.html.twig
@@ -22,7 +22,7 @@
 			<abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
 			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
 			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
-			   title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-software"
+			   title="W3C Software License">permissive document license</a> rules apply.</p>
 	</div>
 </footer>

--- a/design-system-templates/components/footer.html.twig
+++ b/design-system-templates/components/footer.html.twig
@@ -23,6 +23,6 @@
 			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
 			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
 			<a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-software"
-			   title="W3C Software License">permissive document license</a> rules apply.</p>
+			   title="W3C Software and Document License">permissive document license</a> rules apply.</p>
 	</div>
 </footer>


### PR DESCRIPTION
We realised recently in creating snapshots for previous documents that our copyright statement in the footer had a hard-coded link to a now old document. This fixes that.