### PR TITLE
lang/hreflang: replacing _ with -

### DIFF
--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -69,7 +69,8 @@ class TwigExtension extends AbstractExtension
             new TwigFilter('crosslink_type', [$this, 'crosslinkType']),
             new TwigFilter('date_range', [$this, 'dateRange']),
             new TwigFilter('array_shuffle', [$this, 'arrayShuffle']),
-            new TwigFilter('strip_group_type', [$this, 'stripGroupType'])
+            new TwigFilter('strip_group_type', [$this, 'stripGroupType']),
+            new TwigFilter('locale_to_bcp47', [$this, 'localeToBcp47']),
         ];
     }
 
@@ -264,5 +265,10 @@ class TwigExtension extends AbstractExtension
         }
 
         return $this->loginUrlInfo['login_url'] . '?' . $this->loginUrlInfo['login_redirect_param'] . '=' . $redirectUrl;
+    }
+
+    public function localeToBcp47(string $locale): string
+    {
+        return str_replace('_', '-', $locale);
     }
 }

--- a/templates/components/listings/publications/tr_card.html.twig
+++ b/templates/components/listings/publications/tr_card.html.twig
@@ -21,7 +21,7 @@
         <p>{{ spec.translations.translations|length }} translation{% if spec.translations.translations|length > 1 %}s{% endif %}
             ({{ spec.translations.translations
             |sort((a,b) => a.language <=> b.language)
-            |map(t => "<a hreflang=\"#{t.language|replace({'_': '-'})}\" href=\"#{t.uri}\"><span lang=\"#{t.language|replace({'_': '-'})}\">#{t.language|locale_name(t.language)}</span></a>")
+            |map(t => "<a hreflang=\"#{t.language|locale_to_bcp47}\" href=\"#{t.uri}\"><span lang=\"#{t.language|locale_to_bcp47}\">#{t.language|locale_name(t.language)}</span></a>")
             |join(', ')|raw }}) for {{ spec.title }}.</p>
     {% endif %}
     {% endblock translations %}

--- a/templates/components/listings/publications/tr_card.html.twig
+++ b/templates/components/listings/publications/tr_card.html.twig
@@ -21,7 +21,7 @@
         <p>{{ spec.translations.translations|length }} translation{% if spec.translations.translations|length > 1 %}s{% endif %}
             ({{ spec.translations.translations
             |sort((a,b) => a.language <=> b.language)
-            |map(t => "<a hreflang=\"#{t.language}\" href=\"#{t.uri}\"><span lang=\"#{t.language}\">#{t.language|locale_name(t.language)}</span></a>")
+            |map(t => "<a hreflang=\"#{t.language|replace({'_': '-'})}\" href=\"#{t.uri}\"><span lang=\"#{t.language|replace({'_': '-'})}\">#{t.language|locale_name(t.language)}</span></a>")
             |join(', ')|raw }}) for {{ spec.title }}.</p>
     {% endif %}
     {% endblock translations %}


### PR DESCRIPTION
the `lang` and `hreflang` should be valid BCP47 langage tag:
* https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes
* https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-hreflang

According to the [RFC](https://www.rfc-editor.org/rfc/rfc5646.txt), tags can include a "-" but no "_".

This addresses part of https://github.com/w3c/w3c-website/issues/97