### PR TITLE
Error page title

### DIFF
--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -80,6 +80,7 @@ class TwigExtension extends AbstractExtension
             new TwigFunction('date_range', [$this, 'dateRange']),
             new TwigFunction('w3c_date_format', [$this, 'w3cDateFormat']),
             new TwigFunction('login_url', [$this, 'getLoginUrl']),
+            new TwigFunction('class_name', [$this, 'className']),
         ];
     }
 
@@ -270,5 +271,10 @@ class TwigExtension extends AbstractExtension
     public function localeToBcp47(string $locale): string
     {
         return str_replace('_', '-', $locale);
+    }
+
+    public function className($var): string
+    {
+        return gettype($var) === 'object' ? get_class($var) : gettype($var);
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,6 +6,7 @@
 
     {% set seo = page.seo|default([]) %}
     <title>
+        {%- if _context|filter(f => class_name(f) == 'Symfony\\Component\\Form\\FormView' and not f.vars.valid)|length > 0 -%}Error: {% endif -%}
         {%- block documenttitle -%}
             {%- if seo.title is defined and seo.title -%}
                 {{ seo.title|raw }}


### PR DESCRIPTION
That PR adds a new twig function to get the type/class of a variable.
It also prefix the title of a page with 'Error: ' if there are validation errors.

Fix https://github.com/w3c/w3c-website/issues/227