### PR TITLE
update script so it's also compatible with macos

### DIFF
--- a/design-system-build.sh
+++ b/design-system-build.sh
@@ -2,7 +2,7 @@
 
 # Run build commands
 mkdir -p _dist/dist/assets
-cp -r public/dist/assets/ _dist/dist/
+cp -r public/dist/assets/. _dist/dist/assets/
 
 # Copy favicon
 cp public/favicon.ico _dist/favicon.ico


### PR DESCRIPTION
on MacOS, `cp` will not copy the assets to the expected location, which will result into broken assets during a deployment.
That PR fixes the issue