### PR TITLE
Add javascript to sort translations

### DIFF
--- a/assets-src/js/translations-sorting.js
+++ b/assets-src/js/translations-sorting.js
@@ -14,7 +14,7 @@ if (langs.some(i => ["zh-hk", "zh-tw"].includes(i))) {
     langs.splice(Math.max(langs.indexOf("zh-tw"), langs.indexOf("zh-hk")), 0, "zh-hant");
 }
 
-// only look for specs with at least 2 translations
+// only look for lists with at least 2 translations
 const secondTranslations = document.querySelectorAll("div.translation-list > dd:nth-child(3) > a[hreflang], ul.translation-list > li:nth-child(2) > a[hreflang]");
 secondTranslations.forEach((link) => {
     const container = link.parentNode.parentNode;

--- a/assets-src/js/translations-sorting.js
+++ b/assets-src/js/translations-sorting.js
@@ -1,3 +1,6 @@
+/*
+ * translations-sorting: sort a list of translations based on user's preferences
+ */
 const userLangs = navigator.languages || [navigator.language || navigator.userLanguage];
 
 // duplicate to remove variations e.g. fr-fr, fr-ca -> fr

--- a/assets-src/js/translations-sorting.js
+++ b/assets-src/js/translations-sorting.js
@@ -1,0 +1,36 @@
+const userLangs = navigator.languages || [navigator.language || navigator.userLanguage];
+
+// duplicate to remove variations e.g. fr-fr, fr-ca -> fr
+const userLangVars = userLangs.flatMap(i => [i.toLowerCase(), i.split("-")[0].toLowerCase()]);
+const langs = userLangVars.filter((item, index) => userLangVars.indexOf(item) === index);
+// add zh-hans and zh-hant
+if (langs.some(i => ["zh-cn", "zh-sg", "zh"].includes(i))) {
+    langs.splice(Math.max(langs.indexOf("zh-cn"), langs.indexOf("zh-sg"), langs.indexOf("zh")), 0, "zh-hans");
+}
+if (langs.some(i => ["zh-hk", "zh-tw"].includes(i))) {
+    langs.splice(Math.max(langs.indexOf("zh-tw"), langs.indexOf("zh-hk")), 0, "zh-hant");
+}
+
+// only look for specs with at least 2 translations
+const secondTranslations = document.querySelectorAll("div.translation-list > dd:nth-child(3) > a[hreflang], ul.translation-list > li:nth-child(2) > a[hreflang]");
+secondTranslations.forEach((link) => {
+    const container = link.parentNode.parentNode;
+    const children = container.querySelectorAll("dd, li");
+    const sortedChildren = [...children].sort((a, b) => {
+        const aLang = a.firstElementChild.getAttribute("hreflang").toLowerCase();
+        const bLang = b.firstElementChild.getAttribute("hreflang").toLowerCase();
+        const aIndex = langs.indexOf(aLang);
+        const bIndex = langs.indexOf(bLang);
+        if (aIndex === -1 && bIndex === -1) {
+            return 0;
+        } else if (aIndex === -1) {
+            return 1;
+        } else if (bIndex === -1) {
+            return -1;
+        } else {
+            return aIndex - bIndex;
+        }
+    });
+
+    sortedChildren.forEach(element => container.appendChild(element));
+});

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -71,6 +71,7 @@ class TwigExtension extends AbstractExtension
             new TwigFilter('array_shuffle', [$this, 'arrayShuffle']),
             new TwigFilter('strip_group_type', [$this, 'stripGroupType']),
             new TwigFilter('locale_to_bcp47', [$this, 'localeToBcp47']),
+            new TwigFilter('bcp47_to_locale', [$this, 'bcp47ToLocale']),
         ];
     }
 
@@ -270,5 +271,10 @@ class TwigExtension extends AbstractExtension
     public function localeToBcp47(string $locale): string
     {
         return str_replace('_', '-', $locale);
+    }
+
+    public function bcp47ToLocale(string $locale): string
+    {
+        return str_replace('-', '_', $locale);
     }
 }

--- a/templates/components/listings/publications/tr_card.html.twig
+++ b/templates/components/listings/publications/tr_card.html.twig
@@ -29,7 +29,7 @@
     {% endblock editors %}
     {% block translations %}
     {% if spec.translations and spec.translations.translations|length > 0 %}
-        <div>
+        <div class="translation-list">
             <dt>{{ spec.translations.translations|length }} translation{% if spec.translations.translations|length > 1 %}s{% endif %} for {{ spec.title }}</dt>
             {% for t in spec.translations.translations|sort((a,b) => a.language <=> b.language) -%}
             <dd><a hreflang="{{ t.language|locale_to_bcp47 }}" href="{{ t.uri }}"><span lang="{{ t.language|locale_to_bcp47 }}">{{ t.language|locale_name(t.language) }}</span></a></dd>

--- a/templates/components/styles/translations-list.html.twig
+++ b/templates/components/styles/translations-list.html.twig
@@ -1,6 +1,6 @@
 <div class="not-sidebar">
     <div class="l-cluster">
-        <ul class="clean-list">
+        <ul class="clean-list translation-list">
             {% for translation in page.localized|sort((a, b) => a.language_code|replace({'-': '_'})|language_name('en') <=> b.language_code|replace({'-': '_'})|language_name('en')) %}
                 <li>
                     <a href="{{ translation.url }}"

--- a/templates/components/styles/translations-list.html.twig
+++ b/templates/components/styles/translations-list.html.twig
@@ -1,14 +1,14 @@
 <div class="not-sidebar">
     <div class="l-cluster">
         <ul class="clean-list translation-list">
-            {% for translation in page.localized|sort((a, b) => a.language_code|replace({'-': '_'})|language_name('en') <=> b.language_code|replace({'-': '_'})|language_name('en')) %}
+            {% for translation in page.localized|sort((a, b) => a.language_code|bcp47_to_locale|locale_name('en') <=> b.language_code|bcp47_to_locale|locale_name('en')) %}
                 <li>
                     <a href="{{ translation.url }}"
                        hreflang="{{ translation.language_code }}"
                        lang="{{ translation.language_code }}"
                        dir="auto"
                     >
-                        {{ translation.language_code|replace({'-': '_'})|language_name(translation.language_code) }}
+                        {{ translation.language_code|bcp47_to_locale|locale_name(translation.language_code) }}
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
Fix https://github.com/w3c/w3c-website/issues/97

That PR adds a javascript that sorts the list of translations based on user's preferences.
It can work with both of the following markup:
```html
<ul class="translation-list">
    <li>
        <a href="xxx" hreflang="zh-Hans">简体中文</a>
    </li>
    <li>
        <a href="xxx" hreflang="fr">francais</a>
    </li>
    ...
</ul>
```
```html
<dl>
    <div class="translation-list">
        <dt>List of translations</dt>
        <dd>
            <a href="xxx" hreflang="zh-Hans">简体中文</a>
        </dd>
        <dd>
            <a href="xxx" hreflang="fr">francais</a>
        </dd>
        ...
    </div>
</dl>