### PR TITLE
fix division deprecation

### DIFF
--- a/assets-src/styles/sass/10-functions/_units.scss
+++ b/assets-src/styles/sass/10-functions/_units.scss
@@ -8,7 +8,7 @@ $browser-context: 16; // Default
  #em
  */
 @function em($pixels, $context: $browser-context) {
-	@return #{$pixels/$context}em;
+	@return calc($pixels/$context) + em;
 }
 
 
@@ -16,7 +16,7 @@ $browser-context: 16; // Default
  #rem
  */
 @function rem($pixels, $context: $browser-context) {
-	@return #{$pixels/$context}rem;
+	@return calc($pixels/$context) + rem;
 }
 
 
@@ -24,7 +24,7 @@ $browser-context: 16; // Default
  #px
  */
 @function px($target, $context: $browser-context) {
-	@return #{$target*$context}px
+	@return calc($target*$context) + px;
 }
 
 
@@ -32,7 +32,7 @@ $browser-context: 16; // Default
  #Return a number without a unit
  */
 @function number($target, $context: $browser-context) {
-	@return $target/$context
+	@return calc($target/$context);
 }
 
 
@@ -40,5 +40,5 @@ $browser-context: 16; // Default
  #Remove any unit present to return a unitless number
  */
 @function unitless($number) {
-	@return $number / ($number * 0 + 1);
+	@return calc($number / ($number * 0 + 1));
 }

--- a/assets-src/styles/sass/20-mixins/_media-query.scss
+++ b/assets-src/styles/sass/20-mixins/_media-query.scss
@@ -9,7 +9,7 @@
 	$context: $browser-context
 ) {
 
-	@media screen and (#{$query1}-#{$query2}: $point / $context +em) {
+	@media screen and (#{$query1}-#{$query2}: calc($point / $context) + "em") {
 		@content;
 	}
 


### PR DESCRIPTION
The assets generation returns a bunch of deprecation notices related to the use of `/` (see https://sass-lang.com/documentation/breaking-changes/slash-div).

That PR adds `calc()` wherever it's needed. I made sure the resulting css files are the same.