### PR TITLE
handle click modifiers on cards

### DIFF
--- a/assets-src/js/main/cards.js
+++ b/assets-src/js/main/cards.js
@@ -26,13 +26,16 @@ let cardEnhancement = function () {
 
 			}
 
-			card.addEventListener('click', function() {
+			card.addEventListener('click', function(ev) {
 
+				if (ev.redispatched || ev.target === mainLink) {
+ 					return;
+ 				}
 				let noTextSelected = !window.getSelection().toString();
 				if (noTextSelected) {
-
-					mainLink.click();
-
+					const ev2 = new MouseEvent("click", ev);
+					ev2.redispatched = true;
+					mainLink.dispatchEvent(ev2);
 				}
 
 			});


### PR DESCRIPTION
The cards don't handle the click modifiers correctly. For instance, if you try to ctrl+click on a card, the link will open on a new tab but also on the current tab. That PR fixes this.

Fix https://github.com/w3c/w3c-website/issues/500
