### PR TITLE
rename option for HTML labels

### DIFF
--- a/templates/form/theme.html.twig
+++ b/templates/form/theme.html.twig
@@ -58,13 +58,13 @@
     {% if show_label -%}
         <span {% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>
                 {%- if translation_domain is same as(false) -%}
-                    {%- if html_label is not defined or html_label is same as(false) -%}
+                    {%- if label_html is not defined or label_html is same as(false) -%}
                         {{- label -}}
                     {%- else -%}
                         {{- label|raw -}}
                     {%- endif -%}
                 {%- else -%}
-                    {%- if html_label is not defined or html_label is same as(false) -%}
+                    {%- if label_html is not defined or label_html is same as(false) -%}
                         {{- label|trans(label_translation_parameters, translation_domain) -}}
                     {%- else -%}
                         {{- label|trans(label_translation_parameters, translation_domain)|raw -}}


### PR DESCRIPTION
Starting from symfony 5.1, it is specify HTML in labels with the [option label_html](https://symfony.com/doc/5.4/reference/forms/types/form.html#label-html).
Our current template has [the same feature](https://github.com/w3c/w3c-website-templates-bundle/blob/main/templates/form/theme.html.twig#L37) but with the option html_label.
To ensure consistency, that PR updates the name of the option.