### PR TITLE
Fix for low contrast ratio on focus state

### DIFF
--- a/assets-src/styles/sass/50-core-components/_you-may-also-like.scss
+++ b/assets-src/styles/sass/50-core-components/_you-may-also-like.scss
@@ -20,6 +20,10 @@
 	a:active {
 		color: $white;
 	}
+
+	a:focus {
+		color: $off-black;
+	}
 }
 
 .crosslinks .component--columns--images > ul {


### PR DESCRIPTION
Fixing https://github.com/w3c/w3c-website/issues/600

From this:
<img width="515" alt="image" src="https://github.com/w3c/w3c-website-templates-bundle/assets/7963804/59e2241e-5671-4c2b-bf7f-60856af92927">

To this:
<img width="507" alt="image" src="https://github.com/w3c/w3c-website-templates-bundle/assets/7963804/50e0221a-bd8d-4751-8b3a-67bdd2637836">
