### PR TITLE
Simplify pagination pattern

### DIFF
--- a/design-system-templates/components/pagination.html.twig
+++ b/design-system-templates/components/pagination.html.twig
@@ -1,17 +1,16 @@
-<nav aria-label="pagination" class="l-cluster pagination">
+<nav class="l-cluster pagination" aria-labelledby="pagination">
+    <h2 id="pagination" class="visuallyhidden">Pagination</h2>
 	<ul class="pagination__list">
-		<li><a href="path/to/page">Previous <span class="visuallyhidden">page</span></a></li>
-		<li><a class="pagination__list__first" href="path/to/page"><span class="visuallyhidden">page</span> 1<span
-						class="visuallyhidden"> (first page)</span></a></li>
+		<li><a href="path/to/page">Previous</a></li>
+		<li><a class="pagination__list__first" href="path/to/page"> 1</a></li>
 		<li><a class="ellipsis">&#8230;</a></li>
-		<li><a href="path/to/page"><span class="visuallyhidden">page</span> 6</a></li>
-		<li><a href="path/to/page"><span class="visuallyhidden">page</span> 7</a></li>
-		<li><a href="#" aria-label="page 8" aria-current="page">8</a></li>
-		<li><a href="path/to/page"><span class="visuallyhidden">page</span> 9</a></li>
-		<li><a href="path/to/page"><span class="visuallyhidden">page</span> 10</a></li>
+		<li><a href="path/to/page">6</a></li>
+		<li><a href="path/to/page">7</a></li>
+		<li><a href="#" aria-current="page">8</a></li>
+		<li><a href="path/to/page">9</a></li>
+		<li><a href="path/to/page">10</a></li>
 		<li><a class="ellipsis">&#8230;</a></li>
-		<li><a class="pagination__list__last" href="path/to/page"><span class="visuallyhidden">page</span> 20<span
-						class="visuallyhidden"> (last page)</span></a></li>
-		<li><a href="path/to/page">Next <span class="visuallyhidden">page</span></a></li>
+		<li><a class="pagination__list__last" href="path/to/page">20</a></li>
+		<li><a href="path/to/page">Next</a></li>
 	</ul>
 </nav>

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -8,8 +8,6 @@ Used on various [listing pages](../templates/listings.md).
 
 Note the use of the [cluster layout](../layouts/cluster.md).
 
-The `aria-label` attribute has been added to the `<nav>` element. This is because the main website navigation also uses the `<nav>` element. Where there are multiple`<nav>` elements on a single page, all must be given a unique accessible name via `aria-label`.
+The `aria-labelledby` attribute has been added to the `<nav>` element, which references the ID of the visually-hidden `<h2>` inside the `<nav>`. This is because the main website navigation also uses the `<nav>` element. Where there are multiple `<nav>` elements on a single page, they should all have a unique accessible name.
 
-For all pagination links excluding the current page, `<span class="visuallyhidden">page</span>` is added to provide additional context to the link wording for users of Assistive Technology.
-
-The current page is indicated by `aria-current="page"`. As per the [breadcrumbs component](breadcrumbs.md), it is fully linked so that users of Assistive Technology can find which is the currently active link. The `aria-label`on the current page link provides the same additional context as the visually-hidden span on other pagination links.
+The current page is indicated by `aria-current="page"`. As per the [breadcrumbs component](breadcrumbs.md), it is fully linked so that users of Assistive Technology can find which is the currently active link.

--- a/templates/components/styles/pagination.html.twig
+++ b/templates/components/styles/pagination.html.twig
@@ -2,12 +2,13 @@
     {% set route = app.request.attributes.get('_route') %}
     {% set query = app.request.attributes.get('_route_params')|merge(app.request.query) %}
 
-    <nav aria-label="pagination" class="l-cluster pagination">
+    <nav class="l-cluster pagination" aria-labelledby="pagination">
+        <h2 id="pagination" class="visuallyhidden">{{ pagination.label }}</h2>
         <ul class="pagination__list">
             {% if not pagination.firstPage %}
                 <li>
                     <a rel="prev" href="{{ path(route, query|merge({page: pagination.previous})) }}">
-                        Previous <span class="visuallyhidden">page</span>
+                        Previous
                     </a>
                 </li>
             {% endif %}
@@ -16,8 +17,7 @@
                 <li>
                     <a class="pagination__list__first"
                        href="{{ path(route, query|merge({page: pagination.first})) }}">
-                        <span class="visuallyhidden">page</span> {{ pagination.first }}
-                        <span class="visuallyhidden"> (first page)</span>
+                        {{ pagination.first }}
                     </a>
                 </li>
 
@@ -28,13 +28,12 @@
                 {% if page != pagination.page %}
                     <li>
                         <a href="{{ path(route, query|merge({page: page})) }}">
-                            <span class="visuallyhidden">page</span> {{ page }}
+                            {{ page }}
                         </a>
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ path(route, query|merge({page: page})) }}" aria-label="page {{ page }}"
-                           aria-current="page">{{ page }}</a>
+                        <a href="{{ path(route, query|merge({page: page})) }}" aria-current="page">{{ page }}</a>
                     </li>
                 {% endif %}
             {% endfor %}
@@ -45,8 +44,7 @@
                 <li>
                     <a class="pagination__list__last"
                        href="{{ path(route, query|merge({page: pagination.last})) }}">
-                        <span class="visuallyhidden">page</span> {{ pagination.last }}
-                        <span class="visuallyhidden"> (last page)</span>
+                        {{ pagination.last }}
                     </a>
                 </li>
             {% endif %}
@@ -54,7 +52,7 @@
             {% if not pagination.lastPage %}
                 <li>
                     <a rel="next" href="{{ path(route, query|merge({page: pagination.next})) }}">
-                        Next <span class="visuallyhidden">page</span>
+                        Next
                     </a>
                 </li>
             {% endif %}

--- a/translations/w3c_website_templates_bundle+intl-icu.en.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.en.yaml
@@ -61,11 +61,12 @@ header:
 breadcrumbs:
     home: Home
 pagination:
+    label: Pagination
     first: First Page
-    previous: Previous<span class="visuallyhidden">page</span>
-    next: Next <span class="visuallyhidden">page</span>
+    previous: Previous
+    next: Next
     last: Last Page
-    page: "<span class=\"visuallyhidden\">page</span> {page}"
+    page: "{page}"
     current_page: "{page}"
     summary: >-
         {to, select,

--- a/translations/w3c_website_templates_bundle+intl-icu.ja.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.ja.yaml
@@ -59,11 +59,12 @@ header:
 breadcrumbs:
     home: ホーム
 pagination:
+    label: Pagination
     first: 最初のページ
-    previous: 前の<span class="visuallyhidden">ページ</span>
-    next: 次の<span class="visuallyhidden">ページ</span>
+    previous: 前の
+    next: 次の
     last: 最後のページ
-    page: "{page}ページ"
+    page: "{page}"
     current_page: "{page}"
     summary: >-
         {to, select,

--- a/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
@@ -57,11 +57,12 @@ header:
 breadcrumbs:
     home: 主页
 pagination:
+    label: Pagination
     first: 首页
     previous: 上一页
     next: 下一页
     last: 尾页
-    page: "第{page}页"
+    page: "{page}"
     current_page: "{page}"
     summary: >-
         {to, select,


### PR DESCRIPTION
A proposed solution to w3c/w3c-website#634

- Remove visually hidden text from pagination links to reduce verbosity for AT users, improve experience for voice control/Braille display users.
- Use more robust labelling technique for pagination nav.