### PR TITLE
remove anchor from spec title

### DIFF
--- a/templates/components/listings/publications/tr_card.html.twig
+++ b/templates/components/listings/publications/tr_card.html.twig
@@ -1,6 +1,6 @@
 <div class="tr-list__item">
     <div class="tr-list__item__header">
-        <h3>
+        <h3 data-anchor="no">
             <a href="{{ spec.latestVersionUri }}">{{ spec.title }}</a>
         </h3>
         {% block maturity %}{% endblock %}


### PR DESCRIPTION
The anchor is not necessary after each spec title