### PR TITLE
remove the Space between two Chinese characters on the evangelist cards

### DIFF
--- a/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
+++ b/translations/w3c_website_templates_bundle+intl-icu.zh-hans.yaml
@@ -124,9 +124,9 @@ components:
     evangelists:
         list_title: >-
             我们的{ecosystem_name} { count, plural,
-                =0 { 布道者 }
-                one { 布道者 }
-                other { 布道者 }
+                =0 {布道者}
+                one {布道者}
+                other {布道者}
             }
     members:
         title: W3C 会员


### PR DESCRIPTION
I am hoping to remove the unnecessary Space between two Chinese characters (before the word 布道者）on the evangelist cards. For instance, the current [Media & Entertainment evangelist card](https://www.w3.org/zh-hans/ecosystems/media/) says "我们的媒体与娱乐 布道者", which contains an unnecessary space, and it should be “我们的媒体与娱乐布道者”.  I'd like to remove that space from all the evangelist cards. 