### PR TITLE
Add check against site language to navItem language to determine href…

### DIFF
--- a/templates/components/styles/global_nav.html.twig
+++ b/templates/components/styles/global_nav.html.twig
@@ -19,11 +19,12 @@
                             {% if navItem.targetLinkLanguage is not same as siteLang %}
                                 {% set langDiff = true %}
 
-                                {% if navItem.targetLinkLanguage == 'zh-Hans' %}
+                                {# {% if navItem.targetLinkLanguage == 'zh-Hans' %}
                                     {% set targetLangLabel = "Chinese" %}
                                 {% else %}
                                     {% set targetLangLabel = "English" %}
-                                {% endif %}
+                                {% endif %} #}
+                            {% set targetLangLabel = navItem.targetLinkLanguage|replace('-', '_')|language_name(siteLang) %}
                             {% endif %}
                         {% endif %}
                     <a href="{{ navItem.titleLink }}" class="nav-link"{% if langDiff is defined and langDiff %} hreflang="{{ navItem.targetLinkLanguage }}"{% endif %}>
@@ -55,11 +56,12 @@
                                                 {% set targetLangLabel = '' %}
 
                                                 {% if childLangDiff == true %}
-                                                    {% if child.targetLinkLanguage == 'zh-Hans' %}
+                                                    {# {% if child.targetLinkLanguage == 'zh-Hans' %}
                                                         {% set targetLangLabel = "Chinese" %}
                                                     {% else %}
                                                         {% set targetLangLabel = "English" %}
-                                                    {% endif %}
+                                                    {% endif %} #}
+                                                    {% set targetLangLabel = child.targetLinkLanguage|replace('-', '_')|language_name(siteLang) %}
                                                 {% endif %}
                                             {% endif %}
 


### PR DESCRIPTION
This pull request adds support for the "targetLinkLanguage" field that is added by a branch of the same name in the [w3c-website-craft](https://github.com/w3c/w3c-website-craft/tree/hotfix/%23517-menu-target-lang) repo and the [w3c-website-frontend](https://github.com/w3c/w3c-website-frontend/tree/hotfix/%23517-menu-target-lang) repo

When it detects that the language of the current site (`siteLang`) is different from the value of the `targetLinkLanguage` field (if it's populated), it adds a `hreflang` attribute to the relevant `<a>` tag as well as some indicative text following the current text inside the `<a>` tag.

This has been tested locally and seems to be working as intended

**How to test**

1. Ensure you have checked out the branch feature/#517-menu-target-lang in both the front-end and craft repos, and have run the necessary `ddev composer update`s on the frontend and `ddev craft project-config/apply` on the craft repo
2. Go to one of the Main Navigation items in Craft and choose a "Target Link Language" from the dropdown that differs from the language of the site the navigation item belongs to
3. Save your changes and check the front-end

If you would like to test this on another language, you can do the following:

1. Change the language of the Craft dashboard to whichever language you wish to test (e.g Chinese)
2. Repeat steps 2 and 3

**Expected behaviour**

If a navigation item has a Target Link Language that is different from the site language, it should have a `hreflang` in the markup for the anchor tag for that link, and there should be an indicator (in the Roman Alphabet / Romaji) of what language the target page is in. [e.g - Working Groups (Chinese)] or something similar.